### PR TITLE
Remove 911 Domain References

### DIFF
--- a/main.py
+++ b/main.py
@@ -339,7 +339,7 @@ class PhabFox(webapp2.RequestHandler):
 
 
 # Add me as an outgoing webhook for a service in PagerDuty.
-# See http://911.khanacademy.org/ for details.
+# See https://khanacademy.org/r/911 for details.
 class PagerParrot(webapp2.RequestHandler):
     # TODO(benkraft): this has no auth whatsoever.  I'm not too worried about
     # it, but we might want to do some sort of checking (e.g. via hitting the

--- a/pager_parrot.py
+++ b/pager_parrot.py
@@ -106,7 +106,8 @@ _BASE_MESSAGES = {
         in PagerDuty:
         \\n> {summary}\\n
         I'll {next_steps} to make sure someone is looking at it. See
-        <http://911.khanacademy.org/|the 911 docs> for more information
+        <https://docs.google.com/document/d/1LBkjvNxIon5kmZo8gWtT7C_Nq-aWPKD56W4M27a_PjA/edit?usp=sharing|the 911 docs>
+        for more information
         on these alerts.
         """),
     _THIRD_PARTY: _preprocess_base_message(


### PR DESCRIPTION
## Summary:
Removing the 911 domain references now that we plan to completely get
rid of this domain.

Issue: https://khanacademy.atlassian.net/browse/INFRA-7089

## Test plan:
`make test`
Deploy
Run pager parrot test